### PR TITLE
Fixed installation instructions, added example for built-in token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ Useful if only need certain file, like config or
 A list of files with the path relative to the `$GITHUB_WORKSPACE`.
 You can also specify a folder and the action will recessively pull all the files.
 
-```
-- use: Bhacaz/checkout-files
+```yaml
+- name: Check out configuration
+  uses: Bhacaz/checkout-files@v1
   with:
     files: Gemfile Gemfile.lock .ruby-version config
+    token: ${{ github.token }}
 ```
 
 **token**
 
 A Github Private Access Token.
 
-```
-- use: Bhacaz/checkout-files
+```yaml
+- uses: Bhacaz/checkout-files@v1
   with:
     token: ${{ secrets.token }}
 ```


### PR DESCRIPTION
Fixes #1 
Fixes #7 

Problem
- The documented installation instructions are flagged invalid by GitHub
    - `use:` should be `uses:`
    - the specified action must include a version
- The documentation does not mention the built-in repo token from GitHub.

Details
- https://github.com/actions/checkout supplies a token scoped to the current repository by default.