### PR TITLE
Added input for branch name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ A Github Private Access Token.
     token: ${{ secrets.token }}
 ```
 
+**branch**
+
+Checkout the files from a specific branch instead of master.
+
+```
+- uses: Bhacaz/checkout-files
+  with:
+    branch: ${{ input.branch }}
+```
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Checkout the files from a specific branch instead of master.
 ```
 - uses: Bhacaz/checkout-files
   with:
-    branch: ${{ input.branch }}
+    branch: ${{ github.event.inputs.branch }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   token:
     description: 'A Github Private Access Token'
     required: true
+  branch:
+    description: 'Branch to checkout files from'
+    required: false
+    default: master
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -10,12 +10,14 @@ const repository = process.env['GITHUB_REPOSITORY']
 
 const owner = repository.split('/')[0]
 const repo = repository.split('/')[1]
+const ref = core.getInput('branch');
 
 function getContent(path) {
     octokit.repos.getContent({
         owner,
         repo,
         path,
+        ref,
     }).then(data => {
         if (Array.isArray(data.data)) {
             data.data.forEach(fileData => getContent(fileData.path))


### PR DESCRIPTION
Problem
- When trying to deploy code from a particular branch, the checkout-files action only retrieves files from master.

Proposed solution
1. Add an optional input parameter to specify the branch name, defaulting to master.

Fixes #8 